### PR TITLE
Read reCAPTCHA secret from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # Modops
 Modops
+
+## Environment variables
+
+The form uses Google's reCAPTCHA service. Provide your secret key through the
+`RECAPTCHA_SECRET` environment variable so that `views/form.php` can verify
+incoming requests.
+
+Example setup on a UNIX shell:
+
+```sh
+export RECAPTCHA_SECRET=your-secret-key
+```
+
+Ensure this variable is available to the PHP process (for example via your
+web server or deployment configuration).

--- a/views/form.php
+++ b/views/form.php
@@ -9,7 +9,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
     // Verify reCAPTCHA response
     $recaptcha_response = $_POST['g-recaptcha-response'];
-    $secret_key = '';
+    // Read the reCAPTCHA secret key from the environment
+    $secret_key = isset($_ENV['RECAPTCHA_SECRET']) ? $_ENV['RECAPTCHA_SECRET'] : '';
     $url = 'https://www.google.com/recaptcha/api/siteverify';
     $data = [
         'secret'   => $secret_key,


### PR DESCRIPTION
## Summary
- read reCAPTCHA secret from `$_ENV['RECAPTCHA_SECRET']`
- document `RECAPTCHA_SECRET` environment variable setup

## Testing
- `php -l views/form.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ec1dd9c90832492b2643aceb3a4b3