### PR TITLE
Improve language handling

### DIFF
--- a/conv.php
+++ b/conv.php
@@ -1,13 +1,12 @@
 <?php
     session_start();
 
-    if (isset($_GET['lang'])) {
-        $_SESSION['lang'] = $_GET['lang'];
-    }
-
+    $allowed = ['en', 'de', 'nl'];
     $current_lang = $_SESSION['lang'] ?? 'en';
-
-    include "languages/$current_lang.php";
+    if (isset($_GET['lang']) && in_array($_GET['lang'], $allowed, true)) {
+        $current_lang = $_GET['lang'];
+    }
+    include __DIR__ . "/languages/{$current_lang}.php";
 
     
     include('views/header.php');
@@ -15,5 +14,4 @@
     include('views/nav.php');
     include('views/succes.php');
     include('views/footer.php');
-    include('views/cb.php');
-?>
+    include('views/cb.php');?>

--- a/cp.php
+++ b/cp.php
@@ -1,16 +1,14 @@
 <?php
     session_start();
 
-    if (isset($_GET['lang'])) {
-        $_SESSION['lang'] = $_GET['lang'];
-    }
-
+    $allowed = ['en', 'de', 'nl'];
     $current_lang = $_SESSION['lang'] ?? 'en';
-
-    include "languages/$current_lang.php";
+    if (isset($_GET['lang']) && in_array($_GET['lang'], $allowed, true)) {
+        $current_lang = $_GET['lang'];
+    }
+    include __DIR__ . "/languages/{$current_lang}.php";
 
     include('views/header.php');
     include('views/cp.php');
     include('views/footer.php');
-    include('views/cb.php');
-?>
+    include('views/cb.php');?>

--- a/index.php
+++ b/index.php
@@ -1,13 +1,12 @@
 <?php
     session_start();
 
-    if (isset($_GET['lang'])) {
-        $_SESSION['lang'] = $_GET['lang'];
-    }
-
+    $allowed = ['en', 'de', 'nl'];
     $current_lang = $_SESSION['lang'] ?? 'en';
-
-    include "languages/$current_lang.php";
+    if (isset($_GET['lang']) && in_array($_GET['lang'], $allowed, true)) {
+        $current_lang = $_GET['lang'];
+    }
+    include __DIR__ . "/languages/{$current_lang}.php";
     
     include('views/header.php');
     include('views/form.php');

--- a/pp.php
+++ b/pp.php
@@ -1,16 +1,14 @@
 <?php
     session_start();
 
-    if (isset($_GET['lang'])) {
-        $_SESSION['lang'] = $_GET['lang'];
-    }
-
+    $allowed = ['en', 'de', 'nl'];
     $current_lang = $_SESSION['lang'] ?? 'en';
-
-    include "languages/$current_lang.php";
+    if (isset($_GET['lang']) && in_array($_GET['lang'], $allowed, true)) {
+        $current_lang = $_GET['lang'];
+    }
+    include __DIR__ . "/languages/{$current_lang}.php";
 
     include('views/header.php');
     include('views/pp.php');
     include('views/footer.php');
-    include('views/cb.php');
-?>
+    include('views/cb.php');?>

--- a/tac.php
+++ b/tac.php
@@ -1,13 +1,12 @@
 <?php
     session_start();
 
-    if (isset($_GET['lang'])) {
-        $_SESSION['lang'] = $_GET['lang'];
-    }
-
+    $allowed = ['en', 'de', 'nl'];
     $current_lang = $_SESSION['lang'] ?? 'en';
-
-    include "languages/$current_lang.php";
+    if (isset($_GET['lang']) && in_array($_GET['lang'], $allowed, true)) {
+        $current_lang = $_GET['lang'];
+    }
+    include __DIR__ . "/languages/{$current_lang}.php";
 
     include('views/header.php');
     include('views/tac.php');


### PR DESCRIPTION
## Summary
- sanitize incoming lang query values
- load allowed languages and reject unexpected inputs

## Testing
- `php -l index.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ec1fe198c8324bc634a98801c5c7f