### PR TITLE
Fix IP API URL and handle fetch errors

### DIFF
--- a/views/form.php
+++ b/views/form.php
@@ -85,8 +85,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $ip_address = $_SERVER['REMOTE_ADDR'];
 
         // Fetch IP location data via ip-api.com
-        $ip_json = @file_get_contents("http://ip-api.com/json/{$ip_address}?fields=status,country,regionName,city,isp,query");
-        $ip_data = json_decode($ip_json, true);
+        $ip_json = @file_get_contents("https://ip-api.com/json/{$ip_address}?fields=status,country,regionName,city,isp,query");
+        if ($ip_json === false) {
+            $ip_data = null;
+        } else {
+            $ip_data = json_decode($ip_json, true);
+        }
 
         if ($ip_data && $ip_data['status'] === 'success') {
             $ip_country = $ip_data['country'] ?? 'Unknown';


### PR DESCRIPTION
## Summary
- use `https` when fetching IP location info
- handle connection failures when reaching the API

## Testing
- `php -l views/form.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686ec2352a9483248be515304e3490b1