### PR TITLE
Add CSRF protection

### DIFF
--- a/views/apply.php
+++ b/views/apply.php
@@ -11,6 +11,7 @@
         <div class="row gx-4 gx-lg-5 justify-content-center mb-5">
             <div class="col-lg-12">
                 <form name="contactForm1" method="post" action="views/form.php" class="p-5 bg-white" onSubmit="gtag('event', 'submit', {'event_category': 'Application'});">
+                    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($_SESSION['csrf_token'] ?? '', ENT_QUOTES | ENT_HTML5, 'UTF-8') ?>">
                     <div class="row form-group">
                         <div class="col-md-6">
                             <label for="fname"><?=$lang['FIRSTNAME']?></label>

--- a/views/form.php
+++ b/views/form.php
@@ -1,4 +1,13 @@
 <?php
+if (session_status() === PHP_SESSION_NONE) {
+    session_start();
+}
+
+// Generate a CSRF token when rendering the form
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
+
 // Initialize variables with default values and error messages
 $fnameErr = $lnameErr = $visitor_emailErr = $contactErr = $countryErr = $motivationErr = '';
 $fname = $lname = $visitor_email = $contact = $country = $availability = $reference = $experience = $motivation = '';
@@ -6,6 +15,12 @@ $language_arr = [];
 
 // Check if the form has been submitted
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (
+        !isset($_POST['csrf_token'], $_SESSION['csrf_token']) ||
+        !hash_equals($_SESSION['csrf_token'], $_POST['csrf_token'])
+    ) {
+        die('Invalid CSRF token');
+    }
 
     // Verify reCAPTCHA response
     $recaptcha_response = $_POST['g-recaptcha-response'];
@@ -126,7 +141,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         // Send email
         mail($to, 'New job application', $email_body, $email_headers);
 
-        // Redirect to confirmation page
+        // Invalidate CSRF token and redirect to confirmation page
+        unset($_SESSION['csrf_token']);
         header('Location: ../conv.php');
         exit;
     }


### PR DESCRIPTION
## Summary
- implement CSRF token generation and verification in form handler
- add hidden token field to the application form

## Testing
- `php -l views/form.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686ec26801348324b4cd4a54c28f475e