### PR TITLE
Fix language dropdown session persistence

### DIFF
--- a/conv.php
+++ b/conv.php
@@ -5,6 +5,7 @@
     $current_lang = $_SESSION['lang'] ?? 'en';
     if (isset($_GET['lang']) && in_array($_GET['lang'], $allowed, true)) {
         $current_lang = $_GET['lang'];
+        $_SESSION['lang'] = $current_lang;
     }
     include __DIR__ . "/languages/{$current_lang}.php";
 
@@ -13,5 +14,4 @@
     include('views/form.php');
     include('views/nav.php');
     include('views/succes.php');
-    include('views/footer.php');
-    include('views/cb.php');?>
+    include('views/footer.php');    include('views/cb.php');?>

--- a/cp.php
+++ b/cp.php
@@ -5,10 +5,10 @@
     $current_lang = $_SESSION['lang'] ?? 'en';
     if (isset($_GET['lang']) && in_array($_GET['lang'], $allowed, true)) {
         $current_lang = $_GET['lang'];
+        $_SESSION['lang'] = $current_lang;
     }
     include __DIR__ . "/languages/{$current_lang}.php";
 
     include('views/header.php');
     include('views/cp.php');
-    include('views/footer.php');
-    include('views/cb.php');?>
+    include('views/footer.php');    include('views/cb.php');?>

--- a/index.php
+++ b/index.php
@@ -5,6 +5,7 @@
     $current_lang = $_SESSION['lang'] ?? 'en';
     if (isset($_GET['lang']) && in_array($_GET['lang'], $allowed, true)) {
         $current_lang = $_GET['lang'];
+        $_SESSION['lang'] = $current_lang;
     }
     include __DIR__ . "/languages/{$current_lang}.php";
     

--- a/pp.php
+++ b/pp.php
@@ -5,10 +5,10 @@
     $current_lang = $_SESSION['lang'] ?? 'en';
     if (isset($_GET['lang']) && in_array($_GET['lang'], $allowed, true)) {
         $current_lang = $_GET['lang'];
+        $_SESSION['lang'] = $current_lang;
     }
     include __DIR__ . "/languages/{$current_lang}.php";
 
     include('views/header.php');
     include('views/pp.php');
-    include('views/footer.php');
-    include('views/cb.php');?>
+    include('views/footer.php');    include('views/cb.php');?>

--- a/tac.php
+++ b/tac.php
@@ -5,6 +5,7 @@
     $current_lang = $_SESSION['lang'] ?? 'en';
     if (isset($_GET['lang']) && in_array($_GET['lang'], $allowed, true)) {
         $current_lang = $_GET['lang'];
+        $_SESSION['lang'] = $current_lang;
     }
     include __DIR__ . "/languages/{$current_lang}.php";
 

--- a/views/nav.php
+++ b/views/nav.php
@@ -11,8 +11,8 @@
                 <li class="nav-item"><a class="nav-link" href="#apply"><?=$lang['APPLY-NOW']?></a></li>
                 <li class="nav-item"><a class="nav-link" href="#faq"><?=$lang['FAQ']?></a></li>
                 <?php
-                // Bepaal actieve taal vanuit sessie of default
-                $current_lang = isset($_SESSION['lang']) ? $_SESSION['lang'] : 'en';
+                // Gebruik taal uit de pagina of val terug op de sessie
+                $current_lang = $current_lang ?? ($_SESSION['lang'] ?? 'en');
                 $flags = [
                     'en' => ['img' => 'en.png', 'alt' => 'British flag'],
                     'nl' => ['img' => 'nl.png', 'alt' => 'Dutch flag'],


### PR DESCRIPTION
## Summary
- persist the selected language in the session when `lang` query param is used
- make navigation bar reuse the page's active language before falling back to session

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ec3ec538c8324b8ca6d2735cf9068