### PR TITLE
Fix earnings calculator init

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -56,10 +56,11 @@ window.addEventListener('DOMContentLoaded', event => {
         elements: '#portfolio a.portfolio-box'
     });
 
+    // Call earnings calculator once the page has been parsed
+    computeLoon();
 });
 
 // Calculator
-window.onload = computeLoon();
 function computeLoon() {
 var berichten     = document.getElementById('berichten').value;
 var werkDagen     = document.getElementById('werkDagen').value;


### PR DESCRIPTION
## Summary
- initialize the earnings calculator when the DOM is ready

## Testing
- `node js/scripts.js` *(fails: window is not defined)*
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686ec48b7fe48324ac6bd8fc50c00942