### PR TITLE
Convert policy pages to modals

### DIFF
--- a/cp.php
+++ b/cp.php
@@ -1,14 +1,11 @@
 <?php
-    session_start();
-
-    $allowed = ['en', 'de', 'nl'];
-    $current_lang = $_SESSION['lang'] ?? 'en';
-    if (isset($_GET['lang']) && in_array($_GET['lang'], $allowed, true)) {
-        $current_lang = $_GET['lang'];
-        $_SESSION['lang'] = $current_lang;
-    }
-    include __DIR__ . "/languages/{$current_lang}.php";
-
-    include('views/header.php');
-    include('views/cp.php');
-    include('views/footer.php');    include('views/cb.php');?>
+session_start();
+$allowed = ['en','de','nl'];
+$current_lang = $_SESSION['lang'] ?? 'en';
+if (isset($_GET['lang']) && in_array($_GET['lang'], $allowed, true)) {
+    $current_lang = $_GET['lang'];
+    $_SESSION['lang'] = $current_lang;
+}
+$query = http_build_query(['lang' => $current_lang, 'policy' => 'cookie']);
+header('Location: ./index.php?' . $query);
+exit;

--- a/pp.php
+++ b/pp.php
@@ -1,14 +1,11 @@
 <?php
-    session_start();
-
-    $allowed = ['en', 'de', 'nl'];
-    $current_lang = $_SESSION['lang'] ?? 'en';
-    if (isset($_GET['lang']) && in_array($_GET['lang'], $allowed, true)) {
-        $current_lang = $_GET['lang'];
-        $_SESSION['lang'] = $current_lang;
-    }
-    include __DIR__ . "/languages/{$current_lang}.php";
-
-    include('views/header.php');
-    include('views/pp.php');
-    include('views/footer.php');    include('views/cb.php');?>
+session_start();
+$allowed = ['en','de','nl'];
+$current_lang = $_SESSION['lang'] ?? 'en';
+if (isset($_GET['lang']) && in_array($_GET['lang'], $allowed, true)) {
+    $current_lang = $_GET['lang'];
+    $_SESSION['lang'] = $current_lang;
+}
+$query = http_build_query(['lang' => $current_lang, 'policy' => 'privacy']);
+header('Location: ./index.php?' . $query);
+exit;

--- a/tac.php
+++ b/tac.php
@@ -1,16 +1,11 @@
 <?php
-    session_start();
-
-    $allowed = ['en', 'de', 'nl'];
-    $current_lang = $_SESSION['lang'] ?? 'en';
-    if (isset($_GET['lang']) && in_array($_GET['lang'], $allowed, true)) {
-        $current_lang = $_GET['lang'];
-        $_SESSION['lang'] = $current_lang;
-    }
-    include __DIR__ . "/languages/{$current_lang}.php";
-
-    include('views/header.php');
-    include('views/tac.php');
-    include('views/footer.php');
-    include('views/cb.php');
-?>
+session_start();
+$allowed = ['en','de','nl'];
+$current_lang = $_SESSION['lang'] ?? 'en';
+if (isset($_GET['lang']) && in_array($_GET['lang'], $allowed, true)) {
+    $current_lang = $_GET['lang'];
+    $_SESSION['lang'] = $current_lang;
+}
+$query = http_build_query(['lang' => $current_lang, 'policy' => 'terms']);
+header('Location: ./index.php?' . $query);
+exit;

--- a/views/cb.php
+++ b/views/cb.php
@@ -3,7 +3,7 @@
   <div style="max-width: 960px; margin: auto;">
     <p style="margin-bottom: 10px;">
       <?= $lang['cookie_message']; ?>
-      <a href="/cp.php" target="_blank"><?= $lang['cookie_policy']; ?></a>.
+      <a href="#" data-bs-toggle="modal" data-bs-target="#cookieModal"><?= $lang['cookie_policy']; ?></a>.
     </p>
     <form id="cookie-form">
       <label><input type="checkbox" disabled checked> <?= $lang['cookie_necessary']; ?></label><br>

--- a/views/cp.php
+++ b/views/cp.php
@@ -1,7 +1,6 @@
 <section class="page-section" id="apply">
   <div class="container px-4 px-lg-5">
     <div class="row gx-4 gx-lg-5 justify-content-center">
-      <a href="https://modops.nl">back</a>
       <h1>Cookie Policy</h1>
       <p><strong>Effective date:</strong> 01-06-2025</p>
 

--- a/views/footer.php
+++ b/views/footer.php
@@ -1,7 +1,7 @@
         <!-- Footer-->
         <footer class="bg-light py-5" id="footer">
             <div class="container px-4 px-lg-5">
-                <div class="small text-center"><a href="https://modops.nl">Home</a> - <a href="tac.php">Terms & Conditions</a> - <a href="pp.php">Privacy Policy</a> - <a href="cp.php">Cookie Policy</a> - <a href="#" onclick="resetCookieConsent(); return false;"><?= $lang['cookie_change_link']; ?></a></p></div>
+                <div class="small text-center"><a href="https://modops.nl">Home</a> - <a href="#" data-bs-toggle="modal" data-bs-target="#termsModal">Terms & Conditions</a> - <a href="#" data-bs-toggle="modal" data-bs-target="#privacyModal">Privacy Policy</a> - <a href="#" data-bs-toggle="modal" data-bs-target="#cookieModal">Cookie Policy</a> - <a href="#" onclick="resetCookieConsent(); return false;"><?= $lang['cookie_change_link']; ?></a></p></div>
                 <div class="mt-5 small text-center">Copyright &copy; <?php echo date('Y') ?> - ModOps.nl - <?=$lang['FOOTER-RIGHTS']?></div>
             </div>
         </footer>
@@ -13,26 +13,37 @@
         <!-- Core theme JS-->
         <script src="js/scripts.js" defer></script>
         <?php include('views/cb.php'); ?>
+        <?php include('views/policy-modals.php'); ?>
         <script>
           document.addEventListener("DOMContentLoaded", function () {
             const consent = JSON.parse(localStorage.getItem('cookieConsent') || '{}');
             const gtagReady = typeof gtag === 'function';
 
             // Alleen op de conversiepagina uitvoeren
-            if (window.location.pathname.includes('conv.php')) {
-              if (consent.marketing && gtagReady) {
-                console.log("✅ Consent gegeven & gtag geladen – event wordt verzonden");
+              if (window.location.pathname.includes('conv.php')) {
+                if (consent.marketing && gtagReady) {
+                  console.log("✅ Consent gegeven & gtag geladen – event wordt verzonden");
 
-                gtag('event', 'form_submission', {
-                  'event_category': 'Application',
-                  'event_label': 'Job Application Sent',
-                  'value': 1
-                });
-              } else {
-                console.warn("⚠️ Geen toestemming of gtag nog niet geladen, event NIET verzonden");
+                  gtag('event', 'form_submission', {
+                    'event_category': 'Application',
+                    'event_label': 'Job Application Sent',
+                    'value': 1
+                  });
+                } else {
+                  console.warn("⚠️ Geen toestemming of gtag nog niet geladen, event NIET verzonden");
+                }
               }
-            }
-          });
+
+              const params = new URLSearchParams(window.location.search);
+              const policy = params.get('policy');
+              if (policy) {
+                const modalEl = document.getElementById(policy + 'Modal');
+                if (modalEl) {
+                  const modal = new bootstrap.Modal(modalEl);
+                  modal.show();
+                }
+              }
+            });
         </script>
     </body>
 </html>

--- a/views/policy-modals.php
+++ b/views/policy-modals.php
@@ -1,0 +1,46 @@
+<!-- Policy Modals -->
+
+<!-- Terms and Conditions Modal -->
+<div class="modal fade" id="termsModal" tabindex="-1" aria-labelledby="termsModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="termsModalLabel">Terms &amp; Conditions</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <?php include('views/tac.php'); ?>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Privacy Policy Modal -->
+<div class="modal fade" id="privacyModal" tabindex="-1" aria-labelledby="privacyModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="privacyModalLabel">Privacy Policy</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <?php include('views/pp.php'); ?>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- Cookie Policy Modal -->
+<div class="modal fade" id="cookieModal" tabindex="-1" aria-labelledby="cookieModalLabel" aria-hidden="true">
+  <div class="modal-dialog modal-lg modal-dialog-scrollable">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="cookieModalLabel">Cookie Policy</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <?php include('views/cp.php'); ?>
+      </div>
+    </div>
+  </div>
+</div>

--- a/views/pp.php
+++ b/views/pp.php
@@ -1,7 +1,6 @@
 <section class="page-section" id="apply">
 	<div class="container px-4 px-lg-5">
-		<div class="row gx-4 gx-lg-5 justify-content-center">
-			<a href="https://modops.nl">back</a>
+                <div class="row gx-4 gx-lg-5 justify-content-center">
 			<h1>PRIVACY POLICY</h1>
 			<p>Effective date: 2024-02-08</p>
 			<p>1. <b>Introduction</b></p>

--- a/views/tac.php
+++ b/views/tac.php
@@ -1,7 +1,6 @@
 <section class="page-section" id="apply">
 	<div class="container px-4 px-lg-5">
-		<div class="row gx-4 gx-lg-5 justify-content-center">
-			<a href="https://modops.nl">back</a>
+                <div class="row gx-4 gx-lg-5 justify-content-center">
 			<h1>TERMS AND CONDITIONS</h1>
 			<p>Last updated: 2024-02-08</p>
 			<p>1. <b>Introduction</b></p>


### PR DESCRIPTION
## Summary
- show the Terms, Privacy and Cookie policies in Bootstrap modals
- link footer and cookie banner to open modals
- auto-open appropriate modal when `policy` query param is present
- redirect old policy pages to index with the matching modal
- remove back links from policy views

## Testing
- `php` command not found, so no tests run

------
https://chatgpt.com/codex/tasks/task_e_686f700aa48483248cf56fa8c79c8e5e